### PR TITLE
26 erro ao instanciar aplicacao

### DIFF
--- a/src/Services/Axios/demandsServices.js
+++ b/src/Services/Axios/demandsServices.js
@@ -418,10 +418,14 @@ export async function getAlertsByDemand(id, startModal) {
 }
 
 export async function getAlertsBySector(id, startModal) {
+  if (!id) {
+    return null;
+  }
   try {
     const response = await APIDemands.get(`alert/sector/${id}`);
     return response.data;
   } catch (error) {
+    console.log(error.response.status);
     if (error.response.status === 500) {
       startModal('O tempo da sua sessão expirou, faça o login novamente');
     } else if (error.response.status !== 401) {

--- a/src/Services/Axios/demandsServices.js
+++ b/src/Services/Axios/demandsServices.js
@@ -425,7 +425,6 @@ export async function getAlertsBySector(id, startModal) {
     const response = await APIDemands.get(`alert/sector/${id}`);
     return response.data;
   } catch (error) {
-    console.log(error.response.status);
     if (error.response.status === 500) {
       startModal('O tempo da sua sessão expirou, faça o login novamente');
     } else if (error.response.status !== 401) {


### PR DESCRIPTION
Signed-off-by: Arthur <arthurarp@hotmail.com>

**Issue:** resolves DITGO/2020-2-SiGeD#26

<!-- OBSERVAÇÕES:
  - X é o número da issue
  - Só utilize o resolves se o PR fechar a issue por completo
-->

## Descrição

Ao abrir o link em localhost:3000 aparece um erro na requisição para o endpoint de alertas.

O erro ocorre pois a aplicação fazia essa requisição, que utiliza um atributo do objeto user como parâmetro, antes do usuário logar-se no site, e o erro ocorre pois como não está logado, o objeto user não está preenchido.

Um if foi adicionado à função que lida com a requisição e se um id do setor for indefinido, ele retorna null significando que sem o id do setor não é possível fazer tal requisição.